### PR TITLE
Improve 'created' event for private and class chat rooms

### DIFF
--- a/packages/chat/client/chatSidebar.coffee
+++ b/packages/chat/client/chatSidebar.coffee
@@ -85,9 +85,15 @@ currentSearchTerm = new ReactiveVar ''
 							userUrl = 'Iemand'
 
 						switch event.type
-							when 'created' then "Chat aangemaakt door #{userUrl} #{time}"
-							when 'joined' then "#{userUrl} is de chat binnengekomen #{time}"
-							when 'left' then "#{userUrl} heeft de chat verlaten #{time}"
+							when 'created'
+								if room.type is 'class'
+									"Chat aangemaakt #{time}"
+								else
+									"Chat aangemaakt door #{userUrl} #{time}"
+							when 'joined'
+								"#{userUrl} is de chat binnengekomen #{time}"
+							when 'left'
+								"#{userUrl} heeft de chat verlaten #{time}"
 					)
 					time: event.time
 					type: event.type

--- a/packages/chat/lib/chatRoom.coffee
+++ b/packages/chat/lib/chatRoom.coffee
@@ -56,10 +56,13 @@ class ChatRoom
 		# @property events
 		# @type Object[]
 		###
-		@events = [{
-			type: 'created'
-			userId: creatorId
-			time: new Date
-		}]
+		@events = (
+			if @type is 'private' then []
+			else [{
+				type: 'created'
+				userId: creatorId
+				time: new Date
+			}]
+		)
 
 @ChatRoom = ChatRoom

--- a/server/migrations.coffee
+++ b/server/migrations.coffee
@@ -69,5 +69,18 @@ Migrations.add
 
 		Grades.update { _id: $in: ids }, $unset: previousValues: yes
 
+Migrations.add
+	version: 7
+	name: "Remove 'created' event in private chatrooms"
+	up: ->
+		ChatRooms.update {
+			type: 'private'
+		}, {
+			$pull: events:
+				type: 'created'
+		}, {
+			multi: yes
+		}
+
 Meteor.startup ->
 	Migrations.migrateTo 'latest'


### PR DESCRIPTION
Instead of when actually creating the ChatRoom.

This improves the 'privacy'  I guess when people just open the chatroom but don't really send a message to it, most of the times it's not really that useful to know when the chatroom was first opened, but only to know when the first message was sent.
