### PR TITLE
magister-binding: use a mutex lock on getMagisterObject

### DIFF
--- a/packages/magister-binding/.npm/package/npm-shrinkwrap.json
+++ b/packages/magister-binding/.npm/package/npm-shrinkwrap.json
@@ -21,9 +21,9 @@
       "from": "assert-plus@>=0.2.0 <0.3.0"
     },
     "async": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "from": "async@>=1.5.2 <2.0.0"
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
+      "from": "async@>=2.0.1 <3.0.0"
     },
     "aws-sign2": {
       "version": "0.6.0",
@@ -118,8 +118,8 @@
       "from": "forever-agent@>=0.6.1 <0.7.0"
     },
     "form-data": {
-      "version": "1.0.0-rc4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc4.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.1.tgz",
       "from": "form-data@>=1.0.0-rc4 <1.1.0"
     },
     "generate-function": {
@@ -234,6 +234,16 @@
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.0.tgz",
       "from": "jsprim@>=1.2.2 <2.0.0"
     },
+    "locks": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/locks/-/locks-0.2.2.tgz",
+      "from": "locks@0.2.2"
+    },
+    "lodash": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.15.0.tgz",
+      "from": "lodash@>=4.8.0 <5.0.0"
+    },
     "marked": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.5.tgz",
@@ -295,8 +305,8 @@
       "from": "sntp@>=1.0.0 <2.0.0"
     },
     "sshpk": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.8.3.tgz",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.9.2.tgz",
       "from": "sshpk@>=1.7.0 <2.0.0",
       "dependencies": {
         "assert-plus": {
@@ -327,8 +337,8 @@
       "from": "supports-color@>=2.0.0 <3.0.0"
     },
     "tough-cookie": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.0.tgz",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.1.tgz",
       "from": "tough-cookie@>=2.3.0 <2.4.0"
     },
     "tunnel-agent": {

--- a/packages/magister-binding/magister-binding.js
+++ b/packages/magister-binding/magister-binding.js
@@ -113,10 +113,9 @@ function getMutex (userId) {
 
 	if (mutex == null) {
 		mutex = locks.createMutex();
+		mutex.lockSync = Meteor.wrapAsync(mutex.lock, mutex);
 		userMutexes.set(userId, mutex);
 	}
-
-	mutex.lockSync = Meteor.wrapAsync(mutex.lock, mutex);
 
 	return mutex;
 }

--- a/packages/magister-binding/magister-binding.js
+++ b/packages/magister-binding/magister-binding.js
@@ -103,6 +103,11 @@ MagisterBinding.createData = function (schoolurl, username, password, userId) {
 	});
 }
 
+/**
+ * @method getMutex
+ * @param {String} userId
+ * @return {Mutex} The mutex for the user, `lockSync` is added to it.
+ */
 function getMutex (userId) {
 	let mutex = userMutexes.get(userId);
 

--- a/packages/magister-binding/magister-binding.js
+++ b/packages/magister-binding/magister-binding.js
@@ -16,6 +16,9 @@ import { AuthError } from 'meteor/simply:external-services-connector';
 const ONLY_RECENT_LIMIT = ms.days(6);
 
 const log = MagisterBinding.log;
+// FIXME: this technically is a memory leak, since no keys are removed, but I
+// don't think this is going to be a problem. And I don't even know what a
+// better way to handle this would be.
 const userMutexes = new Map();
 
 const cache = LRU({

--- a/packages/magister-binding/magister-binding.js
+++ b/packages/magister-binding/magister-binding.js
@@ -9,12 +9,14 @@ import { Magister } from 'meteor/simply:magisterjs';
 import { LRU } from 'meteor/simply:lru';
 import request from 'request';
 import marked from 'marked';
+import locks from 'locks';
 import Future from 'fibers/future';
 import { AuthError } from 'meteor/simply:external-services-connector';
 
 const ONLY_RECENT_LIMIT = ms.days(6);
 
 const log = MagisterBinding.log;
+const userMutexes = new Map();
 
 const cache = LRU({
 	max: 50,
@@ -98,25 +100,52 @@ MagisterBinding.createData = function (schoolurl, username, password, userId) {
 	});
 }
 
+function getMutex (userId) {
+	let mutex = userMutexes.get(userId);
+
+	if (mutex == null) {
+		mutex = locks.createMutex();
+		userMutexes.set(userId, mutex)
+	}
+
+	mutex.lockSync = Meteor.wrapAsync(mutex.lock, mutex);
+
+	return mutex;
+}
+
 /**
  * Gets a magister object for the given `userId`.
  * @method getMagisterObject
  * @private
  * @param {String} userId The ID of the user to get a Magister object for.
  * @param {Boolean} [forceNew=false] Get a new sessionId and Magister object, even when there is a previous one.
+ * @param {Mutex} [mutex] If provided, should be a locked mutex that will be
+ * unlocked by this function.
  * @return {Magister} A Magister object for the given `userId`.
  */
-function getMagisterObject (userId, forceNew = false) {
+function getMagisterObject (userId, forceNew = false, mutex) {
 	check(userId, String);
 	check(forceNew, Boolean);
+	check(mutex, Match.Any);
+
+	// if we already got a mutex object...
+	if (mutex == null) {
+		// we dont have to fetch one...
+		mutex = getMutex(userId);
+		// and we don't have to lock it (we assume it's already locked and we
+		// retrieved the lock).
+		mutex.lockSync();
+	}
 
 	const data = MagisterBinding.storedInfo(userId);
 	if (_.isEmpty(data)) {
 		cache.del(userId);
+		mutex.unlock();
 		throw new Error('No credentials found.');
 	} else {
 		let m = cache.get(userId);
 		if (m !== undefined && !forceNew) {
+			mutex.unlock();
 			return m;
 		}
 
@@ -153,7 +182,7 @@ function getMagisterObject (userId, forceNew = false) {
 				);
 
 				if (useSessionId) { // retry with new sessionId when currently using an older one.
-					return getMagisterObject(userId, true);
+					return getMagisterObject(userId, true, mutex);
 				}
 
 				if (e instanceof AuthError) { // when logging in fails we don't want to send the wrong password anymore to Magister.
@@ -161,6 +190,7 @@ function getMagisterObject (userId, forceNew = false) {
 					MagisterBinding.storedInfo(userId, null);
 				}
 
+				mutex.unlock();
 				throw e;
 			}
 		}
@@ -186,6 +216,7 @@ function getMagisterObject (userId, forceNew = false) {
 			});
 		}
 
+		mutex.unlock();
 		cache.set(userId, magister);
 		return magister;
 	}

--- a/packages/magister-binding/magister-binding.js
+++ b/packages/magister-binding/magister-binding.js
@@ -108,7 +108,7 @@ function getMutex (userId) {
 
 	if (mutex == null) {
 		mutex = locks.createMutex();
-		userMutexes.set(userId, mutex)
+		userMutexes.set(userId, mutex);
 	}
 
 	mutex.lockSync = Meteor.wrapAsync(mutex.lock, mutex);
@@ -475,7 +475,7 @@ MagisterBinding.getStudyUtils = function (userId, options) {
 						const externalFile = convertMagisterFile(userId, path, file);
 						studyUtil.fileIds.push(externalFile._id);
 						files.push(externalFile);
-					})
+					});
 
 					studyUtils.push(studyUtil);
 				});

--- a/packages/magister-binding/package.js
+++ b/packages/magister-binding/package.js
@@ -9,6 +9,7 @@ Package.describe({
 Npm.depends({
 	'request': '2.74.0',
 	'marked': '0.3.5',
+	'locks': '0.2.2',
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
This makes sure that getMagisterObject can't be run concurrently fetching the
Magister object for one user. Which lead to multiple problems, caching
inefficiency being the biggest (and most obvious) one, but also it could lead to
Magister accounts being blocked.

@tomsmeding could you please review this? :P I currently can't test this since my Magister account is blocked.
