### PR TITLE
Fetch users asynchronously

### DIFF
--- a/packages/notices/server/emails.js
+++ b/packages/notices/server/emails.js
@@ -39,7 +39,7 @@ SyncedCron.add({
 		})
 		let notifiedCount = 0
 
-		WaitGroup.forEach(users, (user) => {
+		users.forEach((user) => {
 			const userId = user._id
 
 			functions.updateGrades(userId, false)


### PR DESCRIPTION
&lt;Lieuwex&gt; er staat daar Waitgroup.foreach users
&lt;Lieuwex&gt; naja
&lt;Lieuwex&gt; WaitGroup.foreach(users, functieblabla)
&lt;Lieuwex&gt; moet dan
&lt;Lieuwex&gt; users.forEach(functieblabla) zijn
&lt;Lieuwex&gt; ¯\\\_(ツ)\_/¯
&lt;Lieuwex&gt; alleen voor de users doen graag dan
&lt;Lieuwex&gt; emails mag die asynchroon doen
&lt;Lieuwex&gt; succes
&lt;Lieuwex&gt; bij voorbaat dank :P
&lt;Lieuwex&gt; <3