### PR TITLE
Allow whitespace around $$ in multiline TeX

### DIFF
--- a/packages/magister-binding/magister-binding.js
+++ b/packages/magister-binding/magister-binding.js
@@ -909,7 +909,7 @@ function compileMessageBody (body) {
 	});
 
 	// multiline
-	body = body.replace(/^\$\$$\n((\n|.)+?)\n^\$\$$/gm, function (match, expr) {
+	body = body.replace(/^[ \t]*\$\$[ \t]*$\n((\n|.)+?)\n^[ \t]*\$\$[ \t]*$/gm, function (match, expr) {
 		const url = base + encodeURIComponent(`\\dpi{130} \\large ${expr}`);
 		return `\n\n${genimg(url)}\n\n`;
 	});


### PR DESCRIPTION
@lieuwex mentioned that this might not be a problem because of line trimming elsewhere, but I figured that was too much of an implicit dependency on a totally different piece of code.
So here you go. 🐊